### PR TITLE
Update OTel Collector binding in Tempo config for compatibility with v2.7

### DIFF
--- a/tempo/tempo.yaml
+++ b/tempo/tempo.yaml
@@ -6,7 +6,9 @@ distributor:
     otlp:
       protocols:
         http:
+          endpoint: 0.0.0.0:4318
         grpc:
+          endpoint: 0.0.0.0:4317
 
 ingester:
   max_block_duration: 5m 


### PR DESCRIPTION
### Summary

This PR updates the OpenTelemetry Collector binding configuration in the Tempo config to align with the breaking changes introduced in **Tempo v2.7**.

OpenTelemetry Collector receiver listens on localhost by default
https://grafana.com/docs/tempo/latest/release-notes/v2-7/#opentelemetry-collector-receiver-listens-on-localhost-by-default

### Changes Made
- Updated `tempo.yaml` config to use the new receiver binding syntax introduced in v2.7.
- Verified compatibility with Tempo v2.7 in local development setup.
- Added test screenshots to validate fix.

### Related Issue
Fixes: #1 

---

### 📸 Screenshots

#### ✅ Test Verification (After Fix)
<img width="1245" alt="After_Fix" src="https://github.com/user-attachments/assets/4d0c11a0-ac18-45dd-9ccd-304f59256959" />

#### 🛠️ Before Fix: Collector Error on Startup
<img width="1043" alt="Otel_logs" src="https://github.com/user-attachments/assets/74b5ca2b-700e-4570-8132-33cbcd3b7b1c" />

---

### 🧪 How to Test

1. Run Tempo with the updated `tempo.yaml`
2. Ensure the OTel Collector starts without errors
3. Confirm trace visibility in Grafana UI Tempo

---